### PR TITLE
Adds support for template helpers

### DIFF
--- a/app/initializers/conditional-compile.js
+++ b/app/initializers/conditional-compile.js
@@ -1,0 +1,24 @@
+/* jshint ignore:start */
+
+import Ember from 'ember';
+
+var feature_flags = EMBER_CLI_CONDITIONAL_COMPILE_INJECTIONS;
+
+var initializer = {
+  name: 'ember-cli-conditional-compile-helpers',
+  initialize: function(container, application) {
+    Object.keys(feature_flags).map(function(flag) {
+      Ember.Handlebars.registerHelper('if-flag-' + flag, function(options) {
+        if (feature_flags[flag]) {
+          return options.fn(this);
+        } else {
+          return options.inverse(this);
+        }
+      });
+    });
+  }
+};
+
+export default initializer;
+
+/* jshint ignore:end */

--- a/index.js
+++ b/index.js
@@ -36,31 +36,18 @@ module.exports = {
       ext: 'hbs',
       toTree: function(tree) {
         Object.keys(config.featureFlags).map(function(flag) {
-          if (!config.featureFlags[flag]) {
-            var replaceRegex = new RegExp(
-              '{{#if-flag-' + flag + '}}([\\s\\S]+?){{\\/if-flag-' + flag + '}}',
-              'gmi'
-            );
-            tree = replace(tree, {
-              files: ['**/*'],
-              patterns: [{
-                match: replaceRegex,
-                replacement: ''
-              }]
-            });
-          } else {
-            var replaceRegex = new RegExp(
-              '{{#if-flag-' + flag + '}}([\\s\\S]+?){{\\/if-flag-' + flag + '}}',
-              'gmi'
-            );
-            tree = replace(tree, {
-              files: ['**/*'],
-              patterns: [{
-                match: replaceRegex,
-                replacement: "$1"
-              }]
-            });
-          }
+          var replaceRegex = new RegExp(
+            '{{#if-flag-' + flag + '}}([\\s\\S]*?)(?:{{\/if-flag-' + flag + '}}|(?:{{else}}([\\s\\S]*?){{\/if-flag-' + flag + '}}))',
+            'gmi'
+          );
+          var replacement = config.featureFlags[flag] ? "$1" : "$2";
+          tree = replace(tree, {
+            files: ['**/*'],
+            patterns: [{
+              match: replaceRegex,
+              replacement: replacement
+            }]
+          });
         });
         return templateCompiler(tree);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-conditional-compile",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Conditional compilation (feature-flags) for Ember apps",
   "directories": {
     "doc": "doc"


### PR DESCRIPTION
Start supporting template helpers. Every feature flag gets its own helper. In development/test mode the Handlebar helpers are used -- in production compiles we massage the templates in a preprocessor step to strip out unneeded code. Something like:

```handlebars
{{#if-flag-ENABLE_FOO}}
    <p>I am the walrus</p>
{{/if-flag-ENABLE_FOO}}
```