### PR TITLE
Put condition to check undefined inverse functions

### DIFF
--- a/app/initializers/conditional-compile.js
+++ b/app/initializers/conditional-compile.js
@@ -11,7 +11,7 @@ var initializer = {
       Ember.Handlebars.registerHelper('if-flag-' + flag, function(options) {
         if (feature_flags[flag]) {
           return options.fn(this);
-        } else {
+        } else if (options.inverse) {
           return options.inverse(this);
         }
       });


### PR DESCRIPTION
For some reason no-op for options.inverse isn't working.