### PR TITLE
Ember 2.1 raises a warning if you have more than 1 argument to an initializer

### DIFF
--- a/app/initializers/ember-cli-conditional-compile-features.js
+++ b/app/initializers/ember-cli-conditional-compile-features.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 
 var initializer = {
   name: 'ember-cli-conditional-compile-features',
-  initialize: function(container, application) {
+  initialize: function(application) {
     Ember.Logger.info('Initializing feature flags');
   }
 };


### PR DESCRIPTION
We don't use those arguments anyhow, so we might as well remove them