### PR TITLE
Fix ember deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = {
   enableCompile: false,
 
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     var checker = new VersionChecker(this);
     checker.for('ember', 'bower').assertAbove('1.13.6');
   },


### PR DESCRIPTION
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-conditional-compile`