### PR TITLE
Allow for proper template cache busting 🎉

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,10 @@ module.exports = {
     target.registry.add(
       'htmlbars-ast-plugin', {
         name: 'conditional-compile-template',
-        plugin: TemplateCompiler(config.featureFlags)
+        plugin: TemplateCompiler(config.featureFlags),
+        baseDir: function() {
+          return __dirname;
+        }
       }
     );
   },


### PR DESCRIPTION
Resolves:
```
DEPRECATION: ember-cli-htmlbars is opting out of caching due to an AST plugin that does not provide a caching strategy: `conditional-compile-template`.
```

`ember-cli-htmlbars` was updated with proper cache busting https://github.com/ember-cli/ember-cli-htmlbars/pull/90 so now we can work with template flags in a consistent and reliable way!

This tiny PR fixes #21 !!!!

This PR is based on changes that resolves the same issue in this addon https://github.com/offirgolan/ember-cp-validations/pull/305

Cheers guys! 🍻

