### PR TITLE
Make ember version checker compatible with ember-source

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ module.exports = {
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
     var checker = new VersionChecker(this);
-    checker.for('ember', 'bower').assertAbove('1.13.6');
+    var ember = checker.forEmber();
+    ember.isAbove('1.13.6');
   },
 
   included: function(app, parentAddon) {


### PR DESCRIPTION
Using ember-cli > 2.11 causes this addon to crash upon build since ember is missing from bower. This PR fixes the issue and does what is recommended by [ember-cli-version-checker](https://github.com/ember-cli/ember-cli-version-checker#forember)

