### PR TITLE
Revert the baseDir change and bring back htmlbars cache-busting …

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,7 @@ module.exports = {
     target.registry.add(
       'htmlbars-ast-plugin', {
         name: 'conditional-compile-template',
-        plugin: TemplateCompiler(config.featureFlags),
-        baseDir: function() {
-          return __dirname;
-        }
+        plugin: TemplateCompiler(config.featureFlags)
       }
     );
   },


### PR DESCRIPTION
… and ember-cli deprecation-warning. 

Any registered `htmlbars-ast-plugin` that hasn't specified a `baseDir` will trigger a deprecation-warning that automatically makes htmlbars opt out of all caching:
<img width="961" alt="54b626e0-e930-11e6-9c5c-1db20f3d0cee" src="https://cloud.githubusercontent.com/assets/732505/23015906/ec73283e-f434-11e6-8eab-87ccf233bdc5.png">

It would be a workaround for #28 but would it let this addon work as intended on its master branch without needing to specify a commit before the `baseDir` change was merged. At least until a caching strategy compatible with this addon is provided by htmlbars ([like this](https://github.com/ember-cli/ember-cli-htmlbars/pull/93) or something similar).

