### PR TITLE
Add "plain helpers" that don't rely on interpolate magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,24 +78,24 @@ if (ENABLE_FOO) {
 }
 ```
 
-In Handlebars/HTMLBars templates, you can also make use of the flags using the `if-flag-` block helper:
+In Handlebars/HTMLBars templates, you can also make use of the flags using the `if-flag` block helper:
 
 ```hbs
-{{#if-flag-ENABLE_FOO}}
+{{#if-flag ENABLE_FOO}}
 <p>Foo is enabled! \o/</p>
 {{else}}
 <p>Foo is disabled</p>
-{{/if-flag-ENABLE_FOO}}
+{{/if-flag}}
 ```
 
-You can also use the `unless-flag-` style block helper:
+You can also use the `unless-flag` style block helper:
 
 ```hbs
-{{#unless-flag-ENABLE_FOO}}
+{{#unless-flag ENABLE_FOO}}
 <p>Foo is disabled</p>
 {{else}}
 <p>Foo is enabled! \o/</p>
-{{/unless-flag-ENABLE_FOO}}
+{{/unless-flag}}
 ```
 
 ## Production environment

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -27,9 +27,9 @@ ConditionalTemplateCompiler.prototype.mungeNode = function(node, flag, unless) {
     node.path = b.path('unless');
   }
 
-  node.params = [b.boolean(compileFlags[flag])];
-
   var flagEnabled = compileFlags[flag];
+
+  node.params = [b.boolean(flagEnabled)];
 
   if (unless) {
     flagEnabled = !flagEnabled;
@@ -42,12 +42,18 @@ ConditionalTemplateCompiler.prototype.mungeNode = function(node, flag, unless) {
   }
 };
 
+ConditionalTemplateCompiler.prototype.mungePlainHelperNode = function(node, unless) {
+  var compileFlag = node.params[0]['original'];
+
+  if (!(compileFlag in compileFlags)) {
+    throw 'No compile flag found for ' + compileFlag;
+  }
+
+  this.mungeNode(node, compileFlag, unless);
+};
+
 ConditionalTemplateCompiler.prototype.processParams = function(node) {
   for (var flag in compileFlags) {
-    if (!node.path) {
-      break;
-    }
-
     if (node.path.original === 'if-flag-' + flag) {
       this.mungeNode(node, flag, false);
     }
@@ -56,10 +62,29 @@ ConditionalTemplateCompiler.prototype.processParams = function(node) {
       this.mungeNode(node, flag, true);
     }
   }
+
+  if (node.path.original === 'if-flag') {
+    this.mungePlainHelperNode(node, false);
+  }
+
+  if (node.path.original === 'unless-flag') {
+    this.mungePlainHelperNode(node, true);
+  }
 };
 
 ConditionalTemplateCompiler.prototype.validate = function(node) {
-  return node.type === 'BlockStatement' || node.type === 'MustacheStatement';
+  var nodeType = (node.type === 'BlockStatement' || node.type === 'MustacheStatement');
+
+  if (!nodeType) {
+    return false;
+  }
+
+  return (
+    node.path && (
+      node.path.original.startsWith('if-flag') ||
+      node.path.original.startsWith('unless-flag')
+    )
+  );
 };
 
 module.exports = function(flags) {

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -45,3 +45,21 @@ test('enabled else blocks are not shown', function(assert) {
     assert.equal(find('.disabled_foo').length, 0);
   });
 });
+
+test('new style flag enabled blocks are shown', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(find('.new_flag_enabled_foo').length, 1);
+    assert.equal(find('.new_flag_disabled_foo').length, 0);
+  });
+});
+
+test('new style unless flag enabled blocks are shown', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(find('.new_flag_unless_enabled_bar').length, 1);
+    assert.equal(find('.new_flag_unless_disabled_bar').length, 0);
+  });
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -25,3 +25,15 @@
 {{else}}
 <div class="unless_disabled_bar">DISABLED_BAR!! \o/</div>
 {{/unless-flag-ENABLE_BAR}}
+
+{{#if-flag ENABLE_FOO}}
+  <div class="new_flag_enabled_foo">ENABLED_FOO!! \o/</div>
+{{else}}
+  <div class="new_flag_disabled_foo">DISABLED_FOO!! \o/</div>
+{{/if-flag}}
+
+{{#unless-flag ENABLE_BAR}}
+  <div class="new_flag_unless_enabled_bar">ENABLE_BAR!! \o/</div>
+{{else}}
+  <div class="new_flag_unless_disabled_bar">DISABLED_BAR!! \o/</div>
+{{/unless-flag}}


### PR DESCRIPTION
As long as the arguments can be statically computed at compile time we can use more standard HTMLBars style helpers:

```hbs
{{#if-flag ENABLE_FOO}}
  Enabled!
{{/if-flag}}
```