### PR TITLE
Check ember version in npm and fallback to bower.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
     var checker = new VersionChecker(this);
-    var ember = checker.for('ember', 'bower');
+    var ember = checker.forEmber();
     ember.assertAbove('2.9.0');
   },
 


### PR DESCRIPTION
Ember is included by npm by default since ember-cli 2.10.0.

Resolves error:
```
The addon `ember-cli-conditional-compile` requires the bower package `ember` to be above 2.9.0, but you have undefined.
```

Read more about `forEmber()` here https://github.com/ember-cli/ember-cli-version-checker#forember