### PR TITLE
Use the new `cacheKey` property available to plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-content-security-policy": "0.6.1",
     "ember-cli-dependency-checker": "~1.4.0",
     "ember-cli-eslint": "~3.0.0",
-    "ember-cli-htmlbars": "~1.2.0",
+    "ember-cli-htmlbars": "~1.3.0",
     "ember-cli-htmlbars-inline-precompile": "~0.3.0",
     "ember-cli-ic-ajax": "1.0.0",
     "ember-cli-inject-live-reload": "~1.6.0",
@@ -52,7 +52,8 @@
     "chalk": "~1.1.0",
     "ember-cli-babel": "~5.2.0",
     "ember-cli-version-checker": "~1.2.0",
-    "lodash.merge": "~4.6.0"
+    "lodash.merge": "~4.6.0",
+    "object-hash": "^1.1.8"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,9 +1908,9 @@ ember-cli-htmlbars-inline-precompile@~0.3.0:
     ember-cli-htmlbars "^1.0.0"
     hash-for-dep "^1.0.2"
 
-ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.2.0.tgz#327e1a5dda1c85c6fcf8be888f7894b32c3f393b"
+ember-cli-htmlbars@^1.0.0, ember-cli-htmlbars@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.0.tgz#e090f011239153bf45dab29625f94a46fce205af"
   dependencies:
     broccoli-persistent-filter "^1.0.3"
     ember-cli-version-checker "^1.0.2"
@@ -4067,6 +4067,10 @@ object-assign@^4.0.1, object-assign@^4.1.0:
 object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
+
+object-hash@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.1.8.tgz#28a659cf987d96a4dabe7860289f3b5326c4a03c"
 
 object.omit@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Now that plugins have a cacheKey they can set to help cache-bust HTMLBars fragments we should use it.