### PR TITLE
Replace featureFlags inline by their values when minifying

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "loader.js": "4.2.3"
   },
   "dependencies": {
+    "babel-plugin-inline-replace-variables": "https://github.com/alexBaizeau/babel-plugin-inline-replace-variables.git#8d55becd00acca84b6f301ad346aeed9507949a3",
+    "broccoli-babel-transpiler": "^6.0.0",
     "broccoli-funnel": "~1.1.0",
     "broccoli-replace": "0.12.0",
     "chalk": "~1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -489,6 +489,12 @@ babel-plugin-inline-environment-variables@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz#1f58ce91207ad6a826a8bf645fafe68ff5fe3ffe"
 
+"babel-plugin-inline-replace-variables@https://github.com/alexBaizeau/babel-plugin-inline-replace-variables.git#8d55becd00acca84b6f301ad346aeed9507949a3":
+  version "1.3.0"
+  resolved "https://github.com/alexBaizeau/babel-plugin-inline-replace-variables.git#8d55becd00acca84b6f301ad346aeed9507949a3"
+  dependencies:
+    babylon "^6.17.0"
+
 babel-plugin-jscript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz#8f342c38276e87a47d5fa0a8bd3d5eb6ccad8fcc"
@@ -847,6 +853,10 @@ babylon@^5.8.38:
 babylon@^6.11.0, babylon@^6.15.0, babylon@^6.16.1:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
+
+babylon@^6.17.0:
+  version "6.17.1"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
 
 backbone@^1.1.2:
   version "1.3.3"


### PR DESCRIPTION
This is a redundant operation for uglifyJS but it makes this library
compatible with babili's dead code eliminitation logic.

when minification is enabled
MY_FEATURE_FLAG=false

```
if (MY_FEATURE_FLAG) {
  return x;
} else {
  return y;
}
```
becomes
```
if (false) {
  return x;
} else {
  return y;
}
```
Then babili's/uglifyJS DCE logic turns this code into

```
  return y;
```

I add to pin a package to one of my commit while https://github.com/wssgcg1213/babel-plugin-inline-replace-variables/pull/8 merges 