### PR TITLE
Specify baseDir property of babel plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ module.exports = {
   transpileTree(tree, config) {
     var esTranspiler = require('broccoli-babel-transpiler');
     var inlineFeatureFlags = require('babel-plugin-inline-replace-variables');
+    inlineFeatureFlags.baseDir = function() { return __dirname; };
     var config = this.project.config(EmberApp.env());
     if (!this.enableCompile) {
       return tree;


### PR DESCRIPTION
This suppresses the cache warning thrown by broccoli-babel-transpiler