### PR TITLE
Fix htmlbars version check

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = {
       plugin: TemplateCompiler(config.featureFlags)
     }
 
-    if (this.htmlbarsVersion.satisfies('^1.3.0')) {
+    if (this.htmlbarsVersion.satisfies('>= 1.3.0')) {
       templateCompilerInstance['baseDir'] = function() {
         return __dirname;
       };


### PR DESCRIPTION
The code currently checks that the version of ember-cli-htmlbars satisfies `^1.3.0`, which allows any versions `>=1.3.0` and `<2.0.0`. The second half of that check was surely accidental, so this PR drops the second condition to allow any version of ember-cli-htmlbars `>= 1.3.0`.