### PR TITLE
Support ember-cli-uglify 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,8 @@ node_js:
 sudo: false
 cache: yarn
 
-env:
-  - EMBER_TRY_SCENARIO=default
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
@@ -24,4 +16,4 @@ install:
   - yarn install
 
 script:
-  - npm run test:node && ember try:one $EMBER_TRY_SCENARIO test
+  - yarn test:node && ember try:each

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,34 +1,23 @@
 module.exports = {
+  useYarn: true,
+  useVersionCompatibility: true,
   scenarios: [
     {
-      name: 'default',
-      dependencies: { }
-    },
-    {
-      name: 'ember-release',
-      dependencies: {
-        'ember': 'components/ember#release'
-      },
-      resolutions: {
-        'ember': 'release'
+      name: 'with ember-cli-uglify 1.2.x',
+      npm: {
+        devDependencies: {
+          "ember-cli-uglify": "~1.2.0",
+          "ember-source": ">2.13"
+        }
       }
     },
     {
-      name: 'ember-beta',
-      dependencies: {
-        'ember': 'components/ember#beta'
-      },
-      resolutions: {
-        'ember': 'beta'
-      }
-    },
-    {
-      name: 'ember-canary',
-      dependencies: {
-        'ember': 'components/ember#canary'
-      },
-      resolutions: {
-        'ember': 'canary'
+      name: 'with ember-cli-uglify 2.x',
+      npm: {
+        devDependencies: {
+          "ember-cli-uglify": "~2.0",
+          "ember-source": ">2.13"
+        }
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
     checker.forEmber().assertAbove('2.9.0');
 
     this.htmlbarsVersion = checker.for('ember-cli-htmlbars', 'npm');
+    this.uglifyVersion = checker.for('ember-cli-uglify', 'npm');
   },
 
   included: function(app, parentAddon) {
@@ -32,8 +33,13 @@ module.exports = {
       }
     };
 
-    target.options.minifyJS = merge(target.options.minifyJS, options);
-    this.enableCompile = target.options.minifyJS.enabled;
+    if (this.uglifyVersion.satisfies('>= 2.0.0')) {
+      target.options['ember-cli-uglify'].uglify = merge(target.options['ember-cli-uglify'].uglify, options.options);
+      this.enableCompile = target.options['ember-cli-uglify'].enabled;
+    } else {
+      target.options.minifyJS = merge(target.options.minifyJS, options);
+      this.enableCompile = target.options.minifyJS.enabled;
+    }
 
     var templateCompilerInstance = {
       name: 'conditional-compile-template',

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
     };
 
     if (this.uglifyVersion.satisfies('>= 2.0.0')) {
-      target.options['ember-cli-uglify'].uglify = merge(target.options['ember-cli-uglify'].uglify, options.options);
+      target.options = merge(target.options, { 'ember-cli-uglify': { uglify: options.options } });
       this.enableCompile = target.options['ember-cli-uglify'].enabled;
     } else {
       target.options.minifyJS = merge(target.options.minifyJS, options);
@@ -56,7 +56,7 @@ module.exports = {
       };
     } else {
       console.log(chalk.yellow(
-          'Upgrade to ember-cli-htmlbars >= 1.3.0 to get build caching'
+        'Upgrade to ember-cli-htmlbars >= 1.3.0 to get build caching'
       ));
     }
 
@@ -97,8 +97,8 @@ module.exports = {
 
     if (!config.featureFlags) {
       console.log(chalk.red(
-          'Could not find any feature flags.' +
-          'You may need to add them in your config/environment.js'
+        'Could not find any feature flags.' +
+        'You may need to add them in your config/environment.js'
       ));
       return tree;
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint lib tests",
     "start": "ember server",
     "build": "ember build",
-    "test": "npm run lint && npm run test:node && ember try:testall",
+    "test": "yarn lint && yarn test:node && ember try:testall",
     "test:node": "mocha node-tests"
   },
   "repository": "https://github.com/minichate/ember-cli-conditional-compile.git",
@@ -21,16 +21,16 @@
   "license": "MIT",
   "devDependencies": {
     "babel-eslint": "~7.2.0",
+    "bower": "^1.8.2",
     "broccoli-asset-rev": "~2.5.0",
     "broccoli-test-helper": "^1.1.0",
     "chai": "^4.0.1",
     "co": "^4.6.0",
     "common-tags": "^1.4.0",
-    "ember-cli": "~2.13.2",
     "ember-cli-dependency-checker": "~2.0.0",
     "ember-cli-eslint": "~3.1.0",
-    "ember-cli-htmlbars": "~2.0.1",
     "ember-cli-htmlbars-inline-precompile": "~0.4.3",
+    "ember-cli-htmlbars": "~2.0.1",
     "ember-cli-ic-ajax": "1.0.0",
     "ember-cli-inject-live-reload": "~1.6.0",
     "ember-cli-qunit": "~4.0.0",
@@ -38,13 +38,14 @@
     "ember-cli-shims": "1.1.0",
     "ember-cli-test-loader": "~2.1.0",
     "ember-cli-uglify": "~1.2.0",
+    "ember-cli": "~2.13.2",
     "ember-disable-prototype-extensions": "~1.1.0",
     "ember-disable-proxy-controllers": "~1.0.1",
     "ember-load-initializers": "1.0.0",
     "ember-resolver": "~4.1.0",
     "ember-source": "^2.13.3",
-    "eslint": "~3.19.0",
     "eslint-plugin-ember": "^3.1.2",
+    "eslint": "~3.19.0",
     "glob": "~7.1.0",
     "loader.js": "4.4.0",
     "mocha": "^3.4.2"
@@ -61,7 +62,10 @@
     "object-hash": "^1.1.8"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "versionCompatibility": {
+      "ember": ">2.13"
+    }
   },
   "keywords": [
     "ember-addon",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,6 +1040,10 @@ bower-endpoint-parser@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz#00b565adbfab6f2d35addde977e97962acbcb3f6"
 
+bower@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.2.tgz#adf53529c8d4af02ef24fb8d5341c1419d33e2f7"
+
 brace-expansion@^1.0.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"


### PR DESCRIPTION
This PR Piggybacks on PR#52 and the good work of @GCheung55. 
Adds ember-try scenarios for both ember-cli-uglify 1.20 and 2.x.
It also updates ember-try to use the versionCompatibility flag, in addition, uses yarn to run all tests and package.json scripts.

This fixes #51 in my ember app which is on 
* Ember-cli 2.16
* Ember-source 2.17.0-beta.4
* Ember-cli-uglify 2.x

#52 should probably be closed