### PR TITLE
 Let the addon work in both app and addon

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,8 @@ module.exports = {
     'ENABLE_BAR': true,
     'visit': true,
     'andThen': true,
-    'find': true
+    'find': true,
+    'window': true
   },
   rules: {
     'array-bracket-spacing': ['error', 'never'],

--- a/app/initializers/ember-cli-conditional-compile-features.js
+++ b/app/initializers/ember-cli-conditional-compile-features.js
@@ -1,15 +1,32 @@
 import Ember from 'ember';
+import Environment from '../config/environment';
 
 var initializer = {
   name: 'ember-cli-conditional-compile-features',
   initialize: function(application) {
-    Ember.Logger.info('Initializing feature flags');
+    let config = {
+      enableLogs: true
+    };
+    let envConfig = Environment["conditional-compile-features"];
+    if (typeof envConfig === "object") {
+      Object.keys(envConfig).map(function(key) {
+        config[key] = envConfig[key];
+      });
+    }
+    if (config.enableLogs) {
+      Ember.Logger.info('Initializing feature flags');
+    }
   }
 };
 
 var feature_flags = EMBER_CLI_CONDITIONAL_COMPILE_INJECTIONS;
 Object.keys(feature_flags).map(function(flag) {
-  window[flag] = feature_flags[flag];
-})
+  Object.defineProperty(window, flag, {
+    value: feature_flags[flag],
+    enumerable: true,
+    configurable: false,
+    writable: false
+  });
+});
 
 export default initializer;

--- a/index.js
+++ b/index.js
@@ -21,9 +21,10 @@ module.exports = {
     this.uglifyVersion = checker.for('ember-cli-uglify', 'npm');
   },
 
-  included: function(app, parentAddon) {
-    var target = (parentAddon || app);
-    var config = this.project.config(target.env);
+  included: function(parent) {
+    // https://ember-cli.com/api/classes/Addon.html#method_included
+    var app = parent.app || parent;
+    var config = this.project.config(app.env);
 
     var options = {
       options: {
@@ -34,11 +35,11 @@ module.exports = {
     };
 
     if (this.uglifyVersion.satisfies('>= 2.0.0')) {
-      target.options = merge(target.options, { 'ember-cli-uglify': { uglify: options.options } });
-      this.enableCompile = target.options['ember-cli-uglify'].enabled;
+      app.options = merge(app.options, { 'ember-cli-uglify': { uglify: options.options } });
+      this.enableCompile = app.options['ember-cli-uglify'].enabled;
     } else {
-      target.options.minifyJS = merge(target.options.minifyJS, options);
-      this.enableCompile = target.options.minifyJS.enabled;
+      app.options.minifyJS = merge(app.options.minifyJS, options);
+      this.enableCompile = app.options.minifyJS.enabled;
     }
 
     var templateCompilerInstance = {
@@ -60,7 +61,7 @@ module.exports = {
       ));
     }
 
-    target.registry.add('htmlbars-ast-plugin', templateCompilerInstance);
+    parent.registry.add('htmlbars-ast-plugin', templateCompilerInstance);
   },
 
   setupPreprocessorRegistry: function(type, registry) {

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -63,3 +63,22 @@ test('new style unless flag enabled blocks are shown', function(assert) {
     assert.equal(find('.new_flag_unless_disabled_bar').length, 0);
   });
 });
+
+test('Global flags on window object should be protected', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    try {
+      window.ENABLE_FOO = false;
+    } catch (err) {
+      // do nothing, but satisfy ESLint.
+    }
+    try {
+      window.ENABLE_BAR = true;
+    } catch (err) {
+      // do nothing, but satisfy ESLint.
+    }
+    assert.equal(true, window.ENABLE_FOO);
+    assert.equal(false, window.ENABLE_BAR);
+  });
+});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -25,6 +25,9 @@ module.exports = function(environment) {
       // when it is created
     },
 
+    'conditional-compile-features': {
+      enableLogs: true
+    },
     featureFlags: {
       ENABLE_FOO: true,
       ENABLE_BAR: false


### PR DESCRIPTION
1. Let the addon work in both app and addon. Previously it's working perfectly in app, but not inside another addon. Right now it should be working in both.
2. Support addon options which is named `conditional-compile-features`  to be able to disable the log `Initializing feature flags` when first startup the application.
3. The feature flags are injected to window object, now they are protected not to be modified once it's created.