### PR TITLE
Remove 'Initializing feature flags' message

### DIFF
--- a/app/initializers/ember-cli-conditional-compile-features.js
+++ b/app/initializers/ember-cli-conditional-compile-features.js
@@ -1,10 +1,5 @@
-import Ember from 'ember';
-
 var initializer = {
-  name: 'ember-cli-conditional-compile-features',
-  initialize: function(application) {
-    Ember.Logger.info('Initializing feature flags');
-  }
+  name: 'ember-cli-conditional-compile-features'
 };
 
 var feature_flags = EMBER_CLI_CONDITIONAL_COMPILE_INJECTIONS;

--- a/app/initializers/ember-cli-conditional-compile-features.js
+++ b/app/initializers/ember-cli-conditional-compile-features.js
@@ -1,5 +1,6 @@
 var initializer = {
-  name: 'ember-cli-conditional-compile-features'
+  name: 'ember-cli-conditional-compile-features',
+  initialize: function() {}
 };
 
 var feature_flags = EMBER_CLI_CONDITIONAL_COMPILE_INJECTIONS;


### PR DESCRIPTION
Remove 'Initializing feature flags' message because Ember.Logger is deprecated and the message is not useful.

https://emberjs.com/deprecations/v3.x#toc_use-console-rather-than-ember-logger

Closes https://github.com/minichate/ember-cli-conditional-compile/issues/50.