### PR TITLE
Fix terser errors in specific includeDirByFlag cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var ENV = {
         ENABLE_BAR: true
     },
     includeDirByFlag: {
-        ENABLE_FOO: [/pods\/foos/, /pods\/foo/],
+        ENABLE_FOO: ['pods/foos/**', 'pods/foo/**'],
         ENABLE_BAR: [],
     }
 };


### PR DESCRIPTION
This replaces Funnel/exclude with replace and replaces the full file content with an empty comment that is then erased by Terser

There's a standing bug in the ember-cli pipeline that reintroduces files when they are removed by Funnel with the uncompiled version, leading to not only unwanted output but also potentially code that can't be processed by Terser.

I believe this fixes #59. 

I tried really hard to come up with a repro within the addon test suite, but it's been resisting me pretty hard.

You can find a standalone repro with a minimal new ember app at https://github.com/halfbyte/compile-repro

Just check out, do `yarn install` and then `ember build -e production`

Expected behaviour: Component is not compiled in.
Observed behaviour: Terser borks on a decorator in the component.

The repro uses the current commit on master to ensure compareability.